### PR TITLE
Prevent upstream-proxy from dying when the connection fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,8 +199,15 @@ class UpstreamProxy {
         backend.write(data);
         socket.pipe(backend).pipe(socket);
       });
-
-      backend.connect(route);
+      try {
+        backend.connect(route);
+      } catch(err) {
+        console.log(err);
+        //catch connection errors like 
+        // - ENOTFOUND when a DNS lookup fails
+        // - ECONNREFUSED when the connection attempt is rejected
+        // - others?
+      }
     }).catch((err) => {
       console.log(err);
       try {


### PR DESCRIPTION
Currently, if DNS lookup fails or the host does not respond, upstream-proxy will choke. 

This PR allows upstream-proxy to continue responding to requests even in the event of a DNS failure or a rejected connection attempt.

